### PR TITLE
Fix: update tooltip to use pointFormatter

### DIFF
--- a/src/data-visual/chart/chart.component.ts
+++ b/src/data-visual/chart/chart.component.ts
@@ -76,8 +76,9 @@ export class ChartComponent implements OnInit, OnChanges {
           },
         },
         tooltip: {
-          formatter: function () {
-            return `${this.key}`;
+          headerFormat: '',
+          pointFormatter: function () {
+            return `${this.name}`;
           },
           shared: true,
         },


### PR DESCRIPTION
### Issue
(Pulled from #32) 
> Steps to reproduce:
>
>1. fill out search form and click search
>2. hover over a bubble, the word should be in tooltip
>3. select the bubble by clicking it
>4. stay hovered, observe that "undefined" is now the displayed tooltip value

### Changes
Use change `formatter` to [pointFormatter](https://api.highcharts.com/highcharts/tooltip.pointFormatter) so as to get point data for the tooltip. `this.key` is sometimes undefined in `formatter.


Closes #32 